### PR TITLE
Fix for blurry icons during sizing.

### DIFF
--- a/lib/mmod/favorites.js
+++ b/lib/mmod/favorites.js
@@ -320,7 +320,7 @@ mod.prototype.update = function()
             let child = this.box.get_child_at_index( realIndex );
 
             // Set sizes based on settings, and attempt to support themes as best as possible
-            let iconWidth = this.comfortSettings.favoriteSize, iconHeight = this.comfortSettings.favoriteSize;
+            this.displayed[realIndex].item.icon.setIconSize(this.comfortSettings.favoriteSize);
 
             child.set_size( this.comfortSettings.containerSize, this.comfortSettings.containerSize );
             child.set_y_align( clttr.ActorAlign.CENTER );
@@ -359,7 +359,6 @@ mod.prototype.update = function()
             // 3.8 through 3.14 continuation
             if( !newer_favorites_wrapping )
             {
-                child.get_children()[0].get_children()[0].get_children()[0].set_size( iconWidth, iconHeight );
                 child.get_children()[0].get_children()[0].get_children()[1].set_size( 0, 0 );
             }
             else
@@ -367,12 +366,10 @@ mod.prototype.update = function()
                 // 3.16 continuation
                 if( running_dots )
                 {
-                    child.get_children()[0].get_children()[1].get_children()[0].get_children()[0].set_size( iconWidth, iconHeight );
                     child.get_children()[0].get_children()[1].get_children()[0].get_children()[1].set_size( 0, 0 );
                 }
                 else
                 {
-                    child.get_children()[0].get_children()[0].get_children()[0].get_children()[0].set_size( iconWidth, iconHeight );
                     child.get_children()[0].get_children()[0].get_children()[0].get_children()[1].set_size( 0, 0 );
                 }
                 


### PR DESCRIPTION
The MMOD favorite icons were having their size
set by altering the width and height of the
rasterized image instead of setting the iconSize
property allowing gnome to dynamically size the
icon in a scalable fashion.  This fixes that issue.
