### PR TITLE
Set the minimum preferences widget size.

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -598,8 +598,8 @@ preferences.prototype =
         let labelSpaceAbout = new gtk.Label( { label: "3/3", xalign: 1, hexpand: false } );
         this.gridAbout.attach( labelSpaceAbout, 3, 8, 1, 1 );
 
-
-
+        // set the minimum size of the prefs widget
+        this.notebook.set_size_request(575, 500);
 
         this.notebook.show_all();
         return this.notebook;

--- a/prefs.js
+++ b/prefs.js
@@ -45,6 +45,10 @@ const ICON_EMAIL = ext.path + '/res/img/generic/email/email-24.png';
 const ICON_GNOME = ext.path + '/res/img/gnico/gnome/gnome-24.png';
 const ICON_GLOOK = ext.path + '/res/img/gnico/gnome/gnome-24.png';
 
+// size
+const WIDGET_DEFAULT_WIDTH = 575;
+const WIDGET_DEFAULT_HEIGHT = 500;
+
 
 /**
  * Init
@@ -599,7 +603,7 @@ preferences.prototype =
         this.gridAbout.attach( labelSpaceAbout, 3, 8, 1, 1 );
 
         // set the minimum size of the prefs widget
-        this.notebook.set_size_request(575, 500);
+        this.notebook.set_size_request(WIDGET_DEFAULT_WIDTH, WIDGET_DEFAULT_HEIGHT);
 
         this.notebook.show_all();
         return this.notebook;


### PR DESCRIPTION
The default preferences widget size was considerably small and required resizing or scrolling to view everything on the first tab.  This adjusts the size such that it will show all child widgets and can't be resized lower.  When widgets are added in the future, it will require these values to be updated.
